### PR TITLE
Use retry count from config and explicitly stub network failure cases…

### DIFF
--- a/src/main/scala/com/pbyrne84/github/scala/github/mavensearchcli/maven/client/MavenSearchClient.scala
+++ b/src/main/scala/com/pbyrne84/github/scala/github/mavensearchcli/maven/client/MavenSearchClient.scala
@@ -28,7 +28,6 @@ case class SearchParams(
     retryCount: Int
 ) {
   val versionedModuleName: String = moduleConfig.scalaVersionedName(scalaVersion)
-
 }
 
 object MavenSearchClient extends ZIOServiced[MavenSearchClient] {
@@ -41,7 +40,7 @@ object MavenSearchClient extends ZIOServiced[MavenSearchClient] {
   def searchOrg(
       searchParams: SearchParams
   ): ZIO[NowProvider with MavenSingleSearch with MavenSearchClient, CliException, MavenOrgSearchResult] =
-    serviced(_.searchOrg(searchParams)).retryN(6)
+    serviced(_.searchOrg(searchParams))
 
 }
 

--- a/src/main/scala/com/pbyrne84/github/scala/github/mavensearchcli/maven/client/MavenSingleSearch.scala
+++ b/src/main/scala/com/pbyrne84/github/scala/github/mavensearchcli/maven/client/MavenSingleSearch.scala
@@ -25,8 +25,12 @@ object MavenSingleSearch extends ZIOServiced[MavenSingleSearch] {
   def runQuery(
       searchParams: SearchParams,
       startIndex: Int
-  ): ZIO[NowProvider with MavenSingleSearch, SingleSearchException, MavenOrgSearchResults] =
-    serviced(_.runQuery(searchParams, startIndex))
+  ): ZIO[NowProvider with MavenSingleSearch, SingleSearchException, MavenOrgSearchResults] = {
+    // Trying to make wiremock mock for retryN just turned into a scenario rabbit hole with many hours spent.
+    // It can be done but I cannot be bothered to waste a day for this as it is very easy to get things
+    // like false positives from the complexity of trying to implement the stubbing.
+    serviced(_.runQuery(searchParams, startIndex)).retryN(searchParams.retryCount)
+  }
 }
 
 class MavenSingleSearch(mavenHostUrl: String, pageSize: Int) {

--- a/src/test/scala/com/pbyrne84/github/scala/github/mavensearchcli/maven/client/MavenSearchClientSpec.scala
+++ b/src/test/scala/com/pbyrne84/github/scala/github/mavensearchcli/maven/client/MavenSearchClientSpec.scala
@@ -49,6 +49,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == MissingMavenOrgSearchResult(
             orgSearchTerm,
@@ -108,6 +109,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == FoundMavenOrgSearchResult(RawSearchResult("org", "module-3", "version.3"), moduleConfig)
         )
@@ -139,6 +141,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == FoundMavenOrgSearchResult(RawSearchResult("org", "module-3", "version.3"), moduleConfig)
         )
@@ -171,6 +174,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == FoundMavenOrgSearchResult(RawSearchResult("org", "module-3", "version.3"), moduleConfig)
         )
@@ -199,6 +203,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == FoundMavenOrgSearchResult(RawSearchResult("org", "module-4", "version.4"), moduleConfig)
         )
@@ -229,6 +234,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == FoundMavenOrgSearchResult(RawSearchResult("org", "module-9", "version.9"), moduleConfig)
         )
@@ -259,6 +265,7 @@ object MavenSearchClientSpec extends BaseSpec {
               retryCount = 0
             )
           )
+          _ <- MavenWireMock.verifyNoUnexpectedInteractions
         } yield assertTrue(
           result == MissingMavenOrgSearchResult(
             organisation = orgSearchTerm,

--- a/src/test/scala/com/pbyrne84/github/scala/github/mavensearchcli/shared/wiremock/TestWireMock.scala
+++ b/src/test/scala/com/pbyrne84/github/scala/github/mavensearchcli/shared/wiremock/TestWireMock.scala
@@ -2,22 +2,43 @@ package com.pbyrne84.github.scala.github.mavensearchcli.shared.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import zio.{Task, ZIO}
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object TestWireMock {}
 
 class TestWireMock(val port: Int) {
 
-  println(s"starting testwiremock on port $port")
+  println(s"starting TestWireMock on port $port")
 
   lazy val wireMock = new WireMockServer(port)
 
   def reset: Task[Unit] = {
-    ZIO.attemptBlocking {
+    ZIO.attempt {
       if (!wireMock.isRunning) {
         wireMock.start()
       }
 
       wireMock.resetAll()
+    }
+  }
+
+  def verifyNoUnexpectedInteractions: Task[true] = {
+    ZIO.fromEither {
+      val nearMisses = wireMock.findNearMissesForUnmatchedRequests().getNearMisses.asScala.toList
+      val unexpectedRequests = wireMock.findAllUnmatchedRequests().asScala.toList
+
+      if (nearMisses.isEmpty && unexpectedRequests.isEmpty) {
+        Right(true)
+      } else {
+        // Near misses rely on stubs to be set up.
+        val nearMissErrorMessages = "\n** The following requests were near misses **\n" +
+          nearMisses.map(request => request.toString).mkString("\n")
+
+        val notMatchedErrorMessages = "\n** The following requests were not matched **\n" +
+          unexpectedRequests.map(_.toString)
+
+        Left(new RuntimeException(nearMissErrorMessages + notMatchedErrorMessages))
+      }
     }
   }
 


### PR DESCRIPTION
… adding checks that nothing unexpected was called.

Relying on 404's from things not being stubbed is not the best practiceas it leads to confusion when the warming is not the cause of a problem.

Plus warnings are then ignored which is also not good.